### PR TITLE
Add intention hiding lines not containing selected substring

### DIFF
--- a/src/main/kotlin/com/intellij/ideolog/foldings/FoldingCalculatorTask.kt
+++ b/src/main/kotlin/com/intellij/ideolog/foldings/FoldingCalculatorTask.kt
@@ -16,6 +16,7 @@ import java.util.*
 
 val hiddenItemsKey = Key.create<HashSet<Pair<Int, String>>>("Log.HiddenColumnValues")
 val hiddenSubstringsKey = Key.create<HashSet<String>>("Log.HiddenSubStrings")
+val whitelistedSubstringsKey = Key.create<HashSet<String>>("Log.WhitelistedSubStrings")
 val whitelistedItemsKey = Key.create<HashSet<Pair<Int, String>>>("Log.WhitelistedColumnValues")
 val hideLinesAboveKey= Key.create<Int>("Log.HideLinesAbove")
 val hideLinesBelowKey= Key.create<Int>("Log.HideLinesBelow")
@@ -37,6 +38,7 @@ class FoldingCalculatorTask(project: Project, val editor: Editor, fileName: Stri
   val settings = LogHighlightingSettingsStore.getInstance()
   val hiddenItems = editor.document.getUserData(hiddenItemsKey) ?: emptySet<Pair<Int, String>>()
   val hiddenSubstrings = editor.document.getUserData(hiddenSubstringsKey) ?: emptySet<String>()
+  val whitelistedSubstrings = editor.document.getUserData(whitelistedSubstringsKey) ?: emptySet<String>()
   val whitelistedItems = editor.document.getUserData(whitelistedItemsKey) ?: emptySet<Pair<Int, String>>()
   val hideLinesAbove: Int = editor.document.getUserData(hideLinesAboveKey) ?: -1
   val hideLinesBelow: Int = editor.document.getUserData(hideLinesBelowKey) ?: Int.MAX_VALUE
@@ -155,6 +157,11 @@ class FoldingCalculatorTask(project: Project, val editor: Editor, fileName: Stri
 
     if (hiddenSubstrings.isNotEmpty()) {
       if (hiddenSubstrings.any { line.contains(it) })
+        return false
+    }
+
+    if (whitelistedSubstrings.isNotEmpty()) {
+      if (!whitelistedSubstrings.all { line.contains(it) })
         return false
     }
 

--- a/src/main/kotlin/com/intellij/ideolog/intentions/HideLinesContainingSubstringIntention.kt
+++ b/src/main/kotlin/com/intellij/ideolog/intentions/HideLinesContainingSubstringIntention.kt
@@ -1,66 +1,9 @@
 package com.intellij.ideolog.intentions
 
-import com.intellij.codeInsight.intention.IntentionAction
-import com.intellij.ideolog.fileType.LogFileType
-import com.intellij.ideolog.foldings.FoldingCalculatorTask
 import com.intellij.ideolog.foldings.hiddenSubstringsKey
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiFile
-import java.util.*
 
-class HideLinesContainingSubstringIntention : IntentionAction {
-  var lastSelection = ""
-  override fun getText(): String {
-    return "Hide lines containing '${if (lastSelection.length > 25) lastSelection.substring(0, 25) + "..." else lastSelection}'"
-  }
+class HideLinesContainingSubstringIntention : HideLinesIntention(hiddenSubstringsKey) {
 
-  override fun getFamilyName() = "Logs"
+  override fun getText() = "Hide lines containing '$shortSelection'"
 
-  fun getText(editor: Editor): CharSequence? {
-    val selectionModel = editor.selectionModel
-    var selectionStart = selectionModel.selectionStart
-    var selectionEnd = selectionModel.selectionEnd
-
-
-    if (selectionStart == selectionEnd) {
-      val doc = editor.document.charsSequence
-
-      while (selectionStart > 0 && doc[selectionStart - 1].isLetterOrDigit())
-        selectionStart--
-
-      while (selectionEnd < doc.length && doc[selectionEnd].isLetterOrDigit())
-        selectionEnd++
-    }
-
-    if (selectionEnd - selectionStart > 100 || selectionEnd == selectionStart)
-      return null
-
-    return editor.document.getText(TextRange(selectionStart, selectionEnd))
-  }
-
-  override fun isAvailable(project: Project, editor: Editor, file: PsiFile?): Boolean {
-    if (file?.fileType != LogFileType)
-      return false
-
-    val text = getText(editor)
-    val enabled = text != null
-    if (enabled)
-      lastSelection = text.toString()
-    return enabled
-
-  }
-
-  override fun invoke(project: Project, editor: Editor, file: PsiFile?) {
-    val selection = getText(editor) ?: return
-
-    val set = editor.document.getUserData(hiddenSubstringsKey) ?: HashSet()
-    set.add(selection.toString())
-    editor.document.putUserData(hiddenSubstringsKey, set)
-
-    FoldingCalculatorTask.restartFoldingCalculator(project, editor, file)
-  }
-
-  override fun startInWriteAction() = false
 }

--- a/src/main/kotlin/com/intellij/ideolog/intentions/HideLinesIntention.kt
+++ b/src/main/kotlin/com/intellij/ideolog/intentions/HideLinesIntention.kt
@@ -1,0 +1,64 @@
+package com.intellij.ideolog.intentions
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.ideolog.fileType.LogFileType
+import com.intellij.ideolog.foldings.FoldingCalculatorTask
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+
+abstract class HideLinesIntention(private val key: Key<HashSet<String>>) : IntentionAction {
+  var lastSelection = ""
+  val shortSelection: String
+    get() = if (lastSelection.length > 25) lastSelection.substring(0, 25) + "..." else lastSelection
+
+  override fun getFamilyName() = "Logs"
+
+  fun getText(editor: Editor): CharSequence? {
+    val selectionModel = editor.selectionModel
+    var selectionStart = selectionModel.selectionStart
+    var selectionEnd = selectionModel.selectionEnd
+
+
+    if (selectionStart == selectionEnd) {
+      val doc = editor.document.charsSequence
+
+      while (selectionStart > 0 && doc[selectionStart - 1].isLetterOrDigit())
+        selectionStart--
+
+      while (selectionEnd < doc.length && doc[selectionEnd].isLetterOrDigit())
+        selectionEnd++
+    }
+
+    if (selectionEnd - selectionStart > 100 || selectionEnd == selectionStart)
+      return null
+
+    return editor.document.getText(TextRange(selectionStart, selectionEnd))
+  }
+
+  override fun isAvailable(project: Project, editor: Editor, file: PsiFile?): Boolean {
+    if (file?.fileType != LogFileType)
+      return false
+
+    val text = getText(editor)
+    val enabled = text != null
+    if (enabled)
+      lastSelection = text.toString()
+    return enabled
+
+  }
+
+  override fun invoke(project: Project, editor: Editor, file: PsiFile?) {
+    val selection = getText(editor) ?: return
+
+    val set = editor.document.getUserData(key) ?: HashSet()
+    set.add(selection.toString())
+    editor.document.putUserData(key, set)
+
+    FoldingCalculatorTask.restartFoldingCalculator(project, editor, file)
+  }
+
+  override fun startInWriteAction() = false
+}

--- a/src/main/kotlin/com/intellij/ideolog/intentions/HideLinesNotContainingSubstringIntention.kt
+++ b/src/main/kotlin/com/intellij/ideolog/intentions/HideLinesNotContainingSubstringIntention.kt
@@ -1,0 +1,9 @@
+package com.intellij.ideolog.intentions
+
+import com.intellij.ideolog.foldings.whitelistedSubstringsKey
+
+class HideLinesNotContainingSubstringIntention : HideLinesIntention(whitelistedSubstringsKey) {
+
+  override fun getText() = "Hide lines not containing '$shortSelection'"
+
+}

--- a/src/main/kotlin/com/intellij/ideolog/intentions/ResetHiddenItemsIntention.kt
+++ b/src/main/kotlin/com/intellij/ideolog/intentions/ResetHiddenItemsIntention.kt
@@ -19,14 +19,16 @@ class ResetHiddenItemsIntention : IntentionAction {
 
     val hasHiddenItems = !editor.document.getUserData(hiddenItemsKey).isNullOrEmpty()
     val hasHiddenSubstrings = !editor.document.getUserData(hiddenSubstringsKey).isNullOrEmpty()
+    val hasWhitelistedSubstrings = !editor.document.getUserData(whitelistedSubstringsKey).isNullOrEmpty()
     val hasWhitelistedItems = !editor.document.getUserData(whitelistedItemsKey).isNullOrEmpty()
 
-    return hasHiddenItems || hasHiddenSubstrings || hasWhitelistedItems || editor.document.getUserData(hideLinesAboveKey) != null || editor.getUserData(hideLinesBelowKey) != null
+    return hasHiddenItems || hasHiddenSubstrings || hasWhitelistedSubstrings || hasWhitelistedItems || editor.document.getUserData(hideLinesAboveKey) != null || editor.getUserData(hideLinesBelowKey) != null
   }
 
   override fun invoke(project: Project, editor: Editor, file: PsiFile?) {
     editor.document.putUserData(hiddenItemsKey, null)
     editor.document.putUserData(hiddenSubstringsKey, null)
+    editor.document.putUserData(whitelistedSubstringsKey, null)
     editor.document.putUserData(whitelistedItemsKey, null)
     editor.document.putUserData(hideLinesBelowKey, null)
     editor.document.putUserData(hideLinesAboveKey, null)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -104,6 +104,12 @@
     </intentionAction>
 
     <intentionAction>
+      <className>com.intellij.ideolog.intentions.HideLinesNotContainingSubstringIntention</className>
+      <bundleName>com.intellij.ideolog.intentions.IntentionResources</bundleName>
+      <categoryKey>intention.category.log</categoryKey>
+    </intentionAction>
+
+    <intentionAction>
       <className>com.intellij.ideolog.intentions.LogWhitelistThisIntention</className>
       <bundleName>com.intellij.ideolog.intentions.IntentionResources</bundleName>
       <categoryKey>intention.category.log</categoryKey>


### PR DESCRIPTION
The 'Hide lines containing substring' intention is useful when you have a lot of relevant log records and only few irrelevant. The added intention is useful when there are a few relevant log records and a lot of irrelevant. 

For example, if each log record mentions a user and I'm interested in some particular user, then it is much easier to hide all records not containing a particular userId than to hide each irrelevant userId one by one.