### PR TITLE
Go to prev/next entry actions

### DIFF
--- a/src/main/kotlin/com/intellij/ideolog/editorActions/GoToNextEntryAction.kt
+++ b/src/main/kotlin/com/intellij/ideolog/editorActions/GoToNextEntryAction.kt
@@ -1,0 +1,35 @@
+package com.intellij.ideolog.editorActions
+
+import com.intellij.ideolog.fileType.LogFileType
+import com.intellij.ideolog.highlighting.LogEvent
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+
+class GoToNextEntryAction : AnAction() {
+  override fun actionPerformed(e: AnActionEvent) {
+    val editor = e.dataContext.getData(CommonDataKeys.EDITOR) ?: return
+    val psiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
+    val project = e.dataContext.getData(CommonDataKeys.PROJECT) ?: return
+    val enabled = psiFile.fileType == LogFileType
+    e.presentation.isEnabled = enabled
+    if (enabled) {
+      val foldingModel = editor.foldingModel
+      var event = LogEvent.fromEditor(editor, editor.caretModel.offset)
+      var nextPos = event.endOffset + 1
+      while (nextPos < editor.document.textLength) {
+        if (foldingModel.isOffsetCollapsed(nextPos)) {
+          event = LogEvent.fromEditor(editor, nextPos)
+          nextPos = event.endOffset + 1
+        } else {
+          event = LogEvent.fromEditor(editor, nextPos)
+          val descriptor = OpenFileDescriptor(project, psiFile.virtualFile, event.startOffset)
+          val navigable = descriptor.setUseCurrentWindow(true)
+          if (navigable.canNavigate()) navigable.navigate(true)
+          return
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/intellij/ideolog/editorActions/GoToPrevEntryAction.kt
+++ b/src/main/kotlin/com/intellij/ideolog/editorActions/GoToPrevEntryAction.kt
@@ -1,0 +1,35 @@
+package com.intellij.ideolog.editorActions
+
+import com.intellij.ideolog.fileType.LogFileType
+import com.intellij.ideolog.highlighting.LogEvent
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+
+class GoToPrevEntryAction : AnAction() {
+  override fun actionPerformed(e: AnActionEvent) {
+    val editor = e.dataContext.getData(CommonDataKeys.EDITOR) ?: return
+    val psiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
+    val project = e.dataContext.getData(CommonDataKeys.PROJECT) ?: return
+    val enabled = psiFile.fileType == LogFileType
+    e.presentation.isEnabled = enabled
+    if (enabled) {
+      val foldingModel = editor.foldingModel
+      var event = LogEvent.fromEditor(editor, editor.caretModel.offset)
+      var prevPos = event.startOffset - 1
+      while (prevPos >= 0) {
+        val prevEvent = LogEvent.fromEditor(editor, prevPos)
+        if (foldingModel.isOffsetCollapsed(prevEvent.startOffset)) {
+          event = LogEvent.fromEditor(editor, prevPos)
+          prevPos = event.startOffset - 1
+        } else {
+          val descriptor = OpenFileDescriptor(project, psiFile.virtualFile, prevEvent.startOffset)
+          val navigable = descriptor.setUseCurrentWindow(true)
+          if (navigable.canNavigate()) navigable.navigate(true)
+          return
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -124,5 +124,8 @@
     <action id="Log.GoToNextError" class="com.intellij.ideolog.editorActions.GoToNextErrorAction" text="Go To Next Error in Log">
       <keyboard-shortcut first-keystroke="shift F7" keymap="$default"/>
     </action>
+
+    <action id="Log.GoToPrevEntry" class="com.intellij.ideolog.editorActions.GoToPrevEntryAction" text="Go To Previous Entry in Log"/>
+    <action id="Log.GoToNextEntry" class="com.intellij.ideolog.editorActions.GoToNextEntryAction" text="Go To Next Entry in Log"/>
   </actions>
 </idea-plugin>


### PR DESCRIPTION
They are useful when log entries are multiline or when soft-wrap is enabled and entry doesn't fit screen.