### PR TITLE
Recognize 'warn' severity by default

### DIFF
--- a/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogHighlightingSettingsStore.kt
+++ b/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogHighlightingSettingsStore.kt
@@ -20,7 +20,7 @@ class LogHighlightingSettingsStore : PersistentStateComponent<LogHighlightingSet
     @Language("RegExp")
     val cleanState = State(arrayListOf(
       LogHighlightingPattern(true, "^\\s*e(rror)?\\s*$", LogHighlightingAction.HIGHLIGHT_LINE, Color.RED.rgb, null, true, false, true),
-      LogHighlightingPattern(true, "^\\s*w(arning)?\\s*$", LogHighlightingAction.HIGHLIGHT_LINE, Color(0xff, 0xaa, 0).rgb, null, true, false, false),
+      LogHighlightingPattern(true, "^\\s*w(arn(ing)?)?\\s*$", LogHighlightingAction.HIGHLIGHT_LINE, Color(0xff, 0xaa, 0).rgb, null, true, false, false),
       LogHighlightingPattern(true, "^\\s*i(nfo)?\\s*$", LogHighlightingAction.HIGHLIGHT_LINE, Color(0x3f, 0xbf, 0x3f).rgb, null, false, false, false)
     ), arrayListOf(), arrayListOf(
       LogParsingPattern(true, "Pipe-separated", "^(?s)([^|]*)\\|([^|]*)\\|([^|]*)\\|(.*)$", "HH:mm:ss.SSS", "^\\d", 0, 1, 2),


### PR DESCRIPTION
tune regexp to recognize 'WARN' severity (used almost in every java log)