### PR TITLE
Add hyperlinks of stack traces in Laravel logs

### DIFF
--- a/src/main/kotlin/com/intellij/ideolog/filters/LaravelStackTraceFileFilter.kt
+++ b/src/main/kotlin/com/intellij/ideolog/filters/LaravelStackTraceFileFilter.kt
@@ -49,12 +49,18 @@ class LaravelStackTraceFileFilter(
     val filePathEndIndex = fileUri.lastIndexOf('(')
 
     val filePath = fileUri.substring(0, filePathEndIndex)
-    localFileSystem.findFileByPathIfCached(filePath) ?: return null
+    localFileSystem.findFileByPath(filePath) ?: return null
 
     val possibleDocumentLine = StringUtil.parseInt(fileUri.substring(filePathEndIndex + 1, fileUri.lastIndex), Int.MIN_VALUE)
     if (possibleDocumentLine != Int.MIN_VALUE) {
       documentLine = possibleDocumentLine - 1
     }
-    return LazyFileHyperlinkInfo(project, filePath, documentLine, 0, false)
+    return LinedFileHyperlinkInfo(project, filePath, documentLine)
   }
+
+  class LinedFileHyperlinkInfo(
+    project: Project,
+    val filePath: String,
+    val documentLine: Int,
+  ) : LazyFileHyperlinkInfo(project, filePath, documentLine, 0, false)
 }

--- a/src/main/kotlin/com/intellij/ideolog/filters/LaravelStackTraceFileFilter.kt
+++ b/src/main/kotlin/com/intellij/ideolog/filters/LaravelStackTraceFileFilter.kt
@@ -1,0 +1,60 @@
+package com.intellij.ideolog.filters
+
+import com.intellij.execution.filters.Filter
+import com.intellij.execution.filters.HyperlinkInfo
+import com.intellij.execution.filters.LazyFileHyperlinkInfo
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+class LaravelStackTraceFileFilter(
+  private val project: Project,
+  private val localFileSystem: LocalFileSystem
+) : Filter {
+  companion object {
+    private val LINUX_MACOS_FILE_PATTERN =
+      Pattern.compile("\\B/[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]\\(\\d+\\)")
+    private val WINDOWS_FILE_PATTERN =
+      Pattern.compile("\\b[A-Z]:\\\\[-A-Za-z0-9+$&@#\\\\%=~_!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]\\(\\d+\\)")
+  }
+
+  override fun applyFilter(line: String, entireLength: Int): Filter.Result? {
+    val textStartOffset = entireLength - line.length
+    val items = collectItems(textStartOffset, LINUX_MACOS_FILE_PATTERN.matcher(line)) +
+      collectItems(textStartOffset, WINDOWS_FILE_PATTERN.matcher(line))
+
+    return when (items.size) {
+      0 -> null
+      1 -> Filter.Result(items[0].highlightStartOffset, items[0].highlightEndOffset, items[0].hyperlinkInfo)
+      else -> Filter.Result(items)
+    }
+  }
+
+  private fun collectItems(textStartOffset: Int, matcher: Matcher): List<Filter.ResultItem> {
+    val resultItems = mutableListOf<Filter.ResultItem>()
+    while (matcher.find()) {
+      resultItems.add(Filter.ResultItem(
+        textStartOffset + matcher.start(),
+        textStartOffset + matcher.end(),
+        buildFileHyperlinkInfo(matcher.group()))
+      )
+    }
+    return resultItems
+  }
+
+  private fun buildFileHyperlinkInfo(fileUri: String): HyperlinkInfo? {
+    var documentLine = 0
+    val filePathEndIndex = fileUri.lastIndexOf('(')
+
+    val filePath = fileUri.substring(0, filePathEndIndex)
+    localFileSystem.findFileByPathIfCached(filePath) ?: return null
+
+    val possibleDocumentLine = StringUtil.parseInt(fileUri.substring(filePathEndIndex + 1, fileUri.lastIndex), Int.MIN_VALUE)
+    if (possibleDocumentLine != Int.MIN_VALUE) {
+      documentLine = possibleDocumentLine - 1
+    }
+    return LazyFileHyperlinkInfo(project, filePath, documentLine, 0, false)
+  }
+}

--- a/src/main/kotlin/com/intellij/ideolog/filters/LaravelStackTraceFileFilterProvider.kt
+++ b/src/main/kotlin/com/intellij/ideolog/filters/LaravelStackTraceFileFilterProvider.kt
@@ -1,0 +1,12 @@
+package com.intellij.ideolog.filters
+
+import com.intellij.execution.filters.ConsoleFilterProvider
+import com.intellij.execution.filters.Filter
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+
+class LaravelStackTraceFileFilterProvider : ConsoleFilterProvider {
+  override fun getDefaultFilters(project: Project): Array<Filter> {
+    return arrayOf(LaravelStackTraceFileFilter(project, LocalFileSystem.getInstance()))
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,7 @@
     <editorHighlighterProvider filetype="Log" implementationClass="com.intellij.ideolog.highlighting.LogFileEditorHighlighterProvider" />
     <extendWordSelectionHandler implementation="com.intellij.ideolog.editorActions.ExtendsSelection"/>
     <fileEditorProvider implementation="com.intellij.ideolog.file.LogFileEditorProvider" />
+    <consoleFilterProvider implementation="com.intellij.ideolog.filters.LaravelStackTraceFileFilterProvider"/>
     <!--suppress PluginXmlValidity -->
     <lang.parserDefinition language="LOG" implementationClass="com.intellij.ideolog.psi.LogFileParserDefinition"/>
     <!--suppress PluginXmlValidity -->

--- a/src/test/kotlin/com/intellij/ideolog/filters/LaravelStackTraceFileFilterTest.kt
+++ b/src/test/kotlin/com/intellij/ideolog/filters/LaravelStackTraceFileFilterTest.kt
@@ -1,0 +1,127 @@
+package com.intellij.ideolog.filters
+
+import com.intellij.execution.filters.Filter
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.testFramework.RunsInEdt
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import junit.framework.TestCase
+import org.junit.rules.TemporaryFolder
+
+@RunsInEdt
+internal class LaravelStackTraceFileFilterTests : BasePlatformTestCase() {
+
+  private lateinit var filter: LaravelStackTraceFileFilter
+  private val tmpFolder: TemporaryFolder = TemporaryFolder()
+
+  override fun setUp() {
+    super.setUp()
+    tmpFolder.create()
+    filter = LaravelStackTraceFileFilter(project, LocalFileSystem.getInstance())
+  }
+
+  override fun tearDown() {
+    super.tearDown()
+    tmpFolder.delete()
+  }
+
+  fun `test no file hyperlink`() {
+    assertNoFileHyperlink("")
+    assertNoFileHyperlink("No file hyperlink")
+    assertNoFileHyperlink("""/Users\me/Application.php""")
+    assertNoFileHyperlink("""C:\Users\me/Application.php""")
+  }
+
+  fun `test no Laravel logs file hyperlink`() {
+    assertNoFileHyperlink("/Users/me/Application.php:35")
+    assertNoFileHyperlink("file:///Users/me/Application.php:35")
+    assertNoFileHyperlink("""C:\Users\me\Application.php:35""")
+  }
+
+  fun `test single Laravel logs file hyperlink`() {
+    assertFileHyperlink("/Users/me/Application.php(35)", 0, 29, "/Users/me/Application.php", 35, false)
+    assertFileHyperlink("""C:\Users\me\Application.php(34)""", 0, 31, """C:\Users\me\Application.php""", 34, false)
+  }
+
+  fun `test multiple Laravel logs file hyperlinks`() {
+    assertFileHyperlinks(
+      applyFilter("{ #stacktrace: /Users/me/Application.php(35) /Users/me/Kernel.php(42) }"),
+      listOf(
+        FileLinkInfo(15, 44, "/Users/me/Application.php", 35, false),
+        FileLinkInfo(45, 69, "/Users/me/Kernel.php", 42, false)
+      )
+    )
+  }
+
+  fun `test apply Filter to existing Laravel file path on linux or mac`() {
+    val existingFile = tmpFolder.newFile("Application.php")
+    val filePathLength = existingFile.absolutePath.length
+    assertFileHyperlink("#0 ${existingFile.absolutePath}(2)", 3, 6 + filePathLength, existingFile.absolutePath, 2, true)
+  }
+
+  fun `test apply Filter to multiple existing Laravel files path on linux or mac`() {
+    val firstExistingFile = tmpFolder.newFile("Application.php")
+    val firstFilePathLength = firstExistingFile.absolutePath.length
+    val secondExistingFile = tmpFolder.newFile("Kernel.php")
+    val secondFilePathLength = secondExistingFile.absolutePath.length
+    assertFileHyperlinks(
+      applyFilter("#0 ${firstExistingFile.absolutePath}(2), ${secondExistingFile.absolutePath}(4)"),
+      listOf(
+        FileLinkInfo(3, 6 + firstFilePathLength, firstExistingFile.absolutePath, 2, true),
+        FileLinkInfo(8 + firstFilePathLength, 11 + firstFilePathLength + secondFilePathLength, secondExistingFile.absolutePath, 4, true)
+      )
+    )
+  }
+
+  private fun applyFilter(line: String) = filter.applyFilter(line, line.length)
+
+  private fun assertNoFileHyperlink(text: String) {
+    assertNull(applyFilter(text))
+  }
+
+  private fun assertFileHyperlink(
+    text: String,
+    highlightStartOffset: Int,
+    highlightEndOffset: Int,
+    filePath: String,
+    documentLine: Int,
+    isFileExists: Boolean
+  ) {
+    assertFileHyperlinks(
+      applyFilter(text),
+      listOf(FileLinkInfo(highlightStartOffset, highlightEndOffset, filePath, documentLine, isFileExists))
+    )
+  }
+
+  private fun assertFileHyperlinks(result: Filter.Result?, infos: List<FileLinkInfo>) {
+    assertNotNull(result)
+    result?.let {
+      val items = result.resultItems
+      assertEquals(infos.size, items.size)
+      infos.indices.forEach { assertHyperlink(items[it], infos[it]) }
+    }
+  }
+
+  private fun assertHyperlink(actualItem: Filter.ResultItem, expectedFileLinkInfo: FileLinkInfo) {
+    assertEquals(expectedFileLinkInfo.highlightStartOffset, actualItem.highlightStartOffset)
+    assertEquals(expectedFileLinkInfo.highlightEndOffset, actualItem.highlightEndOffset)
+    if (expectedFileLinkInfo.isFileExists) {
+      assertInstanceOf(actualItem.hyperlinkInfo, LaravelStackTraceFileFilter.LinedFileHyperlinkInfo::class.java)
+      assertFileLink(expectedFileLinkInfo, actualItem.hyperlinkInfo as LaravelStackTraceFileFilter.LinedFileHyperlinkInfo)
+    } else {
+      TestCase.assertNull(actualItem.hyperlinkInfo)
+    }
+  }
+
+  private fun assertFileLink(expected: FileLinkInfo, actual: LaravelStackTraceFileFilter.LinedFileHyperlinkInfo) {
+    assertEquals(expected.filePath, actual.filePath)
+    assertEquals(expected.line, actual.documentLine + 1)
+  }
+
+  data class FileLinkInfo(
+    val highlightStartOffset: Int,
+    val highlightEndOffset: Int,
+    val filePath: String,
+    val line: Int,
+    val isFileExists: Boolean
+  )
+}


### PR DESCRIPTION
I've added support for hyperlinks in the Laravel log stacktrace. 

In the case [Laravel](https://laravel.com/) logs, the position in the file is specified in parentheses: 
```
/Users/me/Application.php(35)
```

While the default format expected the number after the semicolon:
```
/Users/me/Application.php:35
```

The feature is tested on file URI for Windows, Linux, and MacOS.

---

Before:

<img width="800" alt="Screenshot 2023-06-28 at 19 15 20" src="https://github.com/JetBrains/ideolog/assets/55107433/91ef7fee-219d-4f9a-978f-938bf75dda74">

After: 

<img width="800" alt="Screenshot 2023-06-28 at 19 16 07" src="https://github.com/JetBrains/ideolog/assets/55107433/f3ae6eb2-1072-45b2-adb8-44de2b798fb3">
