### PR TITLE
Highlight match feature

### DIFF
--- a/src/main/kotlin/com/intellij/ideolog/highlighting/LogHighlightingIterator.kt
+++ b/src/main/kotlin/com/intellij/ideolog/highlighting/LogHighlightingIterator.kt
@@ -208,7 +208,7 @@ class LogHighlightingIterator(startOffset: Int, private val myEditor: Editor, va
               val bg = info.backgroundColor ?: valueBackground
               val startOffset = token.startOffset + offset + matchGroup.range.first
               val endOffset = token.startOffset + offset + matchGroup.range.last + 1
-
+              // TODO: handle newlines
               matchedPieces.add(
                 EventPiece(
                   startOffset,
@@ -220,6 +220,14 @@ class LogHighlightingIterator(startOffset: Int, private val myEditor: Editor, va
             }
           }
         }
+      }
+
+
+      if (newlineOffset > 0 && newlineOffset < value.length - 1) {
+        matchedPieces.add(EventPiece(token.startOffset + offset, token.startOffset + newlineOffset + offset, TextAttributes(valueForeground, valueBackground, null, null, getFont(valueBold, valueItalic)), token.isSeparator))
+        matchedPieces.add(EventPiece(token.startOffset + newlineOffset + offset, token.endOffset + offset, TextAttributes(valueForeground, valueBackground, null, null, 0), token.isSeparator))
+      } else{
+        matchedPieces.add(EventPiece(token.startOffset + offset, token.endOffset + offset, TextAttributes(valueForeground, valueBackground, null, null, getFont(valueBold, valueItalic)), token.isSeparator)) // todo: lexeme type?
       }
 
       if (matchedPieces.isNotEmpty()) {
@@ -241,31 +249,6 @@ class LogHighlightingIterator(startOffset: Int, private val myEditor: Editor, va
           )
         }
       }
-
-      var prevEnd = token.startOffset + offset
-      val unusedPieces = currentPieces.mapNotNull {
-        val piece = if (it.offsetStart > prevEnd) {
-          EventPiece(prevEnd,
-            it.offsetStart,
-            TextAttributes(valueForeground, valueBackground, null, null, getFont(valueBold, valueItalic)),
-            token.isSeparator
-          )
-        } else null
-        prevEnd = it.offsetEnd
-        piece
-      }
-
-      currentPieces.addAll(unusedPieces)
-      currentPieces.sortBy { it.offsetStart }
-
-      if (newlineOffset > 0 && newlineOffset < value.length - 1) {
-        currentPieces.add(EventPiece(token.startOffset + offset, token.startOffset + newlineOffset + offset, TextAttributes(valueForeground, valueBackground, null, null, getFont(valueBold, valueItalic)), token.isSeparator))
-        currentPieces.add(EventPiece(token.startOffset + newlineOffset + offset, token.endOffset + offset, TextAttributes(valueForeground, valueBackground, null, null, 0), token.isSeparator))
-      } else{
-        currentPieces.add(EventPiece(token.startOffset + offset, token.endOffset + offset, TextAttributes(valueForeground, valueBackground, null, null, getFont(valueBold, valueItalic)), token.isSeparator)) // todo: lexeme type?
-      }
-
-
 
       if (!token.isSeparator)
         valueIndex++

--- a/src/main/kotlin/com/intellij/ideolog/highlighting/LogHighlightingIterator.kt
+++ b/src/main/kotlin/com/intellij/ideolog/highlighting/LogHighlightingIterator.kt
@@ -230,7 +230,7 @@ class LogHighlightingIterator(startOffset: Int, private val myEditor: Editor, va
           TextAttributes(valueForeground, valueBackground, null, null, getFont(valueBold, valueItalic)),
           false
         )
-      ) // todo: lexeme type?
+      )
 
       eventPieces.addAll(
         // cut lines to remove overlapping regions


### PR DESCRIPTION
# Highlight match feature
- [x] Match highlighting
- [x] Compatibility with line highlighting
- [x] Nested matches
- [x] Overlapping matches
- [x] Multiline matches

# How it looks
<img width="760" alt="image" src="https://github.com/JetBrains/ideolog/assets/50983999/a87c5ab3-94b1-4690-a44b-407edf2cfbe4">
<img width="614" alt="image" src="https://github.com/JetBrains/ideolog/assets/50983999/c85872b4-3b34-4e4c-a350-843a2fb2a8ac">

# How it works
When creating a pattern, capture groups should be used. All the capture groups will be highlighted.

1. Use every pattern and find matches in the token
2. Add the line background for line highlighting compatibility
3. Remove all the overlaps, so that every character is present only once and color is displayed correctly even in the case of overlaps.

# What else
- fixed `linesSubSequence` out of bounds bug
- removed unnecessary `token.isSeparator` checks
