### PR TITLE
Better highlighting

### DIFF
--- a/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogFormatTableModel.kt
+++ b/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogFormatTableModel.kt
@@ -72,4 +72,9 @@ class LogFormatTableModel(private var state: LogHighlightingSettingsStore.State)
     state.parsingPatterns.removeAt(index)
     fireTableRowsDeleted(index, index)
   }
+
+  fun getParsingPatterns() = state.parsingPatterns.map {
+    it.uuid to it.name
+  }
+
 }

--- a/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogHighlightingConfigurable.kt
+++ b/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogHighlightingConfigurable.kt
@@ -91,7 +91,9 @@ class LogHighlightingConfigurable : BaseConfigurable() {
           val selectedIndex = patternsTable.selectedRow
           if (selectedIndex >= 0) {
             LogHighlightingPatternSettingsDialog(
-              patternTableModel.getValueAt(selectedIndex, 2) as LogHighlightingPattern).show()
+              patternTableModel.getValueAt(selectedIndex, 2) as LogHighlightingPattern,
+              formatsTableModel.getParsingPatterns()
+            ).show()
           }
         }
       }.createPanel()

--- a/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogHighlightingPatternSettingsDialog.kt
+++ b/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogHighlightingPatternSettingsDialog.kt
@@ -5,15 +5,22 @@ import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.ui.ColorPanel
 import com.intellij.ui.EditorTextField
+import com.intellij.ui.JBIntSpinner
 import java.awt.Component
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.util.*
 import javax.swing.*
 
-class LogHighlightingPatternSettingsDialog(private val item: LogHighlightingPattern) : DialogWrapper(null, true, IdeModalityType.PROJECT) {
+class LogHighlightingPatternSettingsDialog(
+  private val item: LogHighlightingPattern,
+  private val parsingPatterns: List<Pair<UUID, String>>
+) :
+  DialogWrapper(null, true, IdeModalityType.PROJECT) {
   private var myPatternText: EditorTextField? = null
   private var myActionCombo: JComboBox<LogHighlightingAction>? = null
+  private var myFormatCombo: JComboBox<Pair<UUID?, String>>? = null
+  private var myCaptureGroupId: JBIntSpinner? = null
   private var myForegroundCheck: JCheckBox? = null
   private var myBackgroundCheck: JCheckBox? = null
   private var myForegroundColor: ColorPanel? = null
@@ -59,8 +66,56 @@ class LogHighlightingPatternSettingsDialog(private val item: LogHighlightingPatt
     actionSelection.selectedItem = item.action
     myActionCombo = actionSelection
     panel.add(actionSelection, constraints)
-    constraints.gridx = 1
+    constraints.gridx = 0
     panel.add(JLabel("Action"), constraints)
+
+    constraints.gridx = 0
+    constraints.gridy = 2
+    panel.add(JLabel("Format"), constraints)
+    constraints.gridx = 1
+
+    val formatSelection = ComboBox(
+      (listOf(Pair(null, "Any")) + parsingPatterns).toTypedArray()
+    )
+    formatSelection.renderer = object : DefaultListCellRenderer() {
+      override fun getListCellRendererComponent(
+        list: JList<*>?,
+        value: Any?,
+        index: Int,
+        isSelected: Boolean,
+        cellHasFocus: Boolean
+      ): Component {
+        text = if (value is Pair<*, *>) {
+          if (value.first is UUID? && value.second is String) {
+            (value.second as String)
+          } else {
+            ""
+          }
+        } else {
+          ""
+        }
+        return this
+      }
+    }
+
+    formatSelection.selectedIndex = 0
+    for (i in 0 until formatSelection.itemCount) {
+      if (formatSelection.getItemAt(i).first == item.formatId) {
+        formatSelection.selectedIndex = i
+        break
+      }
+    }
+
+    panel.add(formatSelection, constraints)
+    myFormatCombo = formatSelection
+
+    constraints.gridx = 0
+    constraints.gridy = 3
+    panel.add(JLabel("Capture group"), constraints)
+    val groupSpinner = JBIntSpinner(item.captureGroup + 1, 0, 100)
+    myCaptureGroupId = groupSpinner
+    constraints.gridx++
+    panel.add(groupSpinner, constraints)
 
     val fgColor = ColorPanel()
     myForegroundColor = fgColor
@@ -87,20 +142,20 @@ class LogHighlightingPatternSettingsDialog(private val item: LogHighlightingPatt
     myItalicCheck = italicCheck
 
     constraints.gridx = 0
-    constraints.gridy = 2
+    constraints.gridy = 4
     panel.add(boldCheck, constraints)
 
     constraints.gridx = 1
     panel.add(italicCheck, constraints)
 
     constraints.gridx = 0
-    constraints.gridy = 3
+    constraints.gridy = 5
     panel.add(fgCheck, constraints)
 
     constraints.gridx = 1
     panel.add(fgColor, constraints)
 
-    constraints.gridy = 4
+    constraints.gridy = 6
     panel.add(bgColor, constraints)
 
     constraints.gridx = 0
@@ -120,6 +175,8 @@ class LogHighlightingPatternSettingsDialog(private val item: LogHighlightingPatt
     }
     myPatternText?.let { item.pattern = it.text }
     myActionCombo?.let { item.action = it.selectedItem as LogHighlightingAction }
+    myFormatCombo?.let { item.formatId = (it.selectedItem as Pair<*, *>).first as UUID? }
+    myCaptureGroupId?.let { item.captureGroup = it.number - 1 }
     myForegroundCheck?.let {
       item.foregroundColor = if (it.isSelected) myForegroundColor?.selectedColor else null
     }

--- a/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogHighlightingSettingsStore.kt
+++ b/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogHighlightingSettingsStore.kt
@@ -110,6 +110,8 @@ object DefaultSettingsStoreItems {
   val Error = LogHighlightingPattern(
     true,
     "^\\s*(e(rror)?|severe)\\s*$",
+    null,
+    -1,
     LogHighlightingAction.HIGHLIGHT_LINE,
     JBColor.RED.rgb,
     null,
@@ -121,6 +123,8 @@ object DefaultSettingsStoreItems {
   val Warning = LogHighlightingPattern(
     true,
     "^\\s*w(arn(ing)?)?\\s*$",
+    null,
+    -1,
     LogHighlightingAction.HIGHLIGHT_LINE,
     JBColor.ORANGE.rgb,
     null,
@@ -132,6 +136,8 @@ object DefaultSettingsStoreItems {
   val Info = LogHighlightingPattern(
     true,
     "^\\s*i(nfo)?\\s*$",
+    null,
+    -1,
     LogHighlightingAction.HIGHLIGHT_LINE,
     JBColor.GREEN.rgb,
     null,
@@ -434,6 +440,8 @@ data class LogParsingPattern(@Attribute("enabled") var enabled: Boolean,
 @Tag("LogHighlightingPattern")
 data class LogHighlightingPattern(@Attribute("enabled") var enabled: Boolean,
                                   @Attribute("pattern") @Language("RegExp") var pattern: String,
+                                  @Attribute("formatId", converter = UUIDConverter::class) var formatId: UUID?,
+                                  @Attribute("captureGroup") var captureGroup: Int,
                                   @Attribute("action") var action: LogHighlightingAction,
                                   @Attribute("fg") var fgRgb: Int?,
                                   @Attribute("bg") var bgRgb: Int?,
@@ -443,7 +451,7 @@ data class LogHighlightingPattern(@Attribute("enabled") var enabled: Boolean,
                                   @Attribute("uuid", converter = UUIDConverter::class) var uuid: UUID) : Cloneable {
 
   @Suppress("unused")
-  constructor() : this(true, "", LogHighlightingAction.HIGHLIGHT_FIELD, null, null, false, false, false, UUID.randomUUID())
+  constructor() : this(true, "", null, 0, LogHighlightingAction.HIGHLIGHT_FIELD, null, null, false, false, false, UUID.randomUUID())
 
   var foregroundColor: Color?
     @Transient get() = fgRgb?.let { JBColor(it, it) }
@@ -458,7 +466,7 @@ data class LogHighlightingPattern(@Attribute("enabled") var enabled: Boolean,
     }
 
   public override fun clone(): LogHighlightingPattern {
-    return LogHighlightingPattern(enabled, pattern, action, fgRgb, bgRgb, bold, italic, showOnStripe, uuid)
+    return LogHighlightingPattern(enabled, pattern, formatId, captureGroup, action, fgRgb, bgRgb, bold, italic, showOnStripe, uuid)
   }
 }
 

--- a/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogPatternTableModel.kt
+++ b/src/main/kotlin/com/intellij/ideolog/highlighting/settings/LogPatternTableModel.kt
@@ -53,7 +53,7 @@ class LogPatternTableModel(private var store: LogHighlightingSettingsStore.State
   }
 
   fun addNewPattern(pattern: String) {
-    store.patterns.add(LogHighlightingPattern(true, pattern, LogHighlightingAction.HIGHLIGHT_FIELD, null, null, bold = false, italic = false, showOnStripe = true, UUID.randomUUID()))
+    store.patterns.add(LogHighlightingPattern(true, pattern, null, 0, LogHighlightingAction.HIGHLIGHT_FIELD, null, null, bold = false, italic = false, showOnStripe = true, UUID.randomUUID()))
     val index = store.patterns.size - 1
     fireTableRowsInserted(index, index)
   }

--- a/src/main/kotlin/com/intellij/ideolog/lex/LogFileFormats.kt
+++ b/src/main/kotlin/com/intellij/ideolog/lex/LogFileFormats.kt
@@ -58,6 +58,10 @@ class LogFileFormat(val myRegexLogParser: RegexLogParser?) {
     return tokens.last { !it.isSeparator }
   }
 
+  fun validateFormatUUID(uuid: UUID?): Boolean =
+    uuid == null || myRegexLogParser?.uuid == uuid
+
+
   fun parseLogEventTimeSeconds(time: CharSequence): Long? {
     return myRegexLogParser?.let {
       try {


### PR DESCRIPTION
# Features
This PR adds two fields to highlighting settings:
1. Capture group — now you can choose a specific capture group to be matched before applying regexp and highlighting. Leave `0` to match all groups.
2. Format — you can choose a specific parsing format for the highlighting. Leave `Any` to match all formats.
![telegram-cloud-photo-size-2-5433870560384898882-x](https://github.com/JetBrains/ideolog/assets/50983999/496d8591-30df-41b7-86d3-c3a714a0ee69)

# Motivation
Previously highlighting would highlight anything matching the pattern, that would lead to issues like this one.
Here we use the default Error pattern and it works ok with IDEA format, but leads to somewhat strange in a custom one:
![telegram-cloud-photo-size-2-5433870560384898868-y](https://github.com/JetBrains/ideolog/assets/50983999/5b1e064f-0a4a-4837-8931-b0ed362cf5a4)

# How it works now
![telegram-cloud-photo-size-2-5433870560384898882-x](https://github.com/JetBrains/ideolog/assets/50983999/496d8591-30df-41b7-86d3-c3a714a0ee69)
![telegram-cloud-photo-size-2-5433870560384898880-x](https://github.com/JetBrains/ideolog/assets/50983999/5ba249fe-7b8d-4e3f-a4f2-5878579a59f6)
![telegram-cloud-photo-size-2-5433870560384898879-y](https://github.com/JetBrains/ideolog/assets/50983999/58e875c2-0bd5-4a07-b6f0-30f9f6fdb773)