### PR TITLE
Fix offset bug in highlight field

### DIFF
--- a/src/main/kotlin/com/intellij/ideolog/highlighting/LogHighlightingIterator.kt
+++ b/src/main/kotlin/com/intellij/ideolog/highlighting/LogHighlightingIterator.kt
@@ -249,7 +249,7 @@ class LogHighlightingIterator(startOffset: Int, private val myEditor: Editor, va
       matchedPieces.add(
         EventPiece(
           token.startOffset + offset,
-          token.endOffset + offset + 1,
+          token.endOffset + offset,
           TextAttributes(valueForeground, valueBackground, null, null, getFont(valueBold, valueItalic)),
           false
         )


### PR DESCRIPTION
# Before
<img width="248" alt="image" src="https://github.com/JetBrains/ideolog/assets/50983999/f3b9223f-7af0-4149-a460-bd73031e9ec5">

# After
<img width="255" alt="image" src="https://github.com/JetBrains/ideolog/assets/50983999/cf3f06b1-97b8-499b-ad94-a2cd49314712">
