### PR TITLE
Fix extraction from last group

### DIFF
--- a/src/main/kotlin/com/intellij/ideolog/lex/LogFileFormats.kt
+++ b/src/main/kotlin/com/intellij/ideolog/lex/LogFileFormats.kt
@@ -35,21 +35,21 @@ class LogFileFormat(val myRegexLogParser: RegexLogParser?) {
 
   fun extractDate(tokens: List<LogToken>): LogToken? {
     val idx = myRegexLogParser?.otherParsingSettings?.timeColumnId ?: return null
-    if(tokens.size > idx + 1)
+    if(tokens.size > idx)
       return tokens.asSequence().filter { !it.isSeparator }.elementAtOrNull(idx)
     return null
   }
 
   fun extractSeverity(tokens: List<LogToken>): LogToken? {
     val idx = myRegexLogParser?.otherParsingSettings?.severityColumnId ?: return null
-    if(tokens.size > idx + 1)
+    if(tokens.size > idx)
       return tokens.asSequence().filter { !it.isSeparator }.elementAtOrNull(idx)
     return null
   }
 
   fun extractCategory(tokens: List<LogToken>): LogToken? {
     val idx = myRegexLogParser?.otherParsingSettings?.categoryColumnId ?: return null
-    if(tokens.size > idx + 1)
+    if(tokens.size > idx)
       return tokens.asSequence().filter { !it.isSeparator }.elementAtOrNull(idx)
     return null
   }


### PR DESCRIPTION
# Description
Previously, if the line had N groups and Time/Severity/Category capture group was set to N, it would be parsed as `null` due to the `tokens.size > idx + 1` check.

# Note
It might not be a bug if we intentionally parse last token exclusively as `message`, thus making it mandatory.