### PR TITLE
Add Xdebug log highlighting

### DIFF
--- a/formatsDirectory/Xdebug.xml
+++ b/formatsDirectory/Xdebug.xml
@@ -1,0 +1,11 @@
+<State>
+  <highlightingPatterns>
+    <LogHighlightingPattern pattern="^\s*ERR\s*$" formatId="6c083f50-56bc-4e71-9bde-db86a3faa90d" captureGroup="-1" action="HIGHLIGHT_LINE" fg="{&quot;lightRgb&quot;:-39836,&quot;darkRgb&quot;:-39836}" bold="true" uuid="f06c3429-5799-49cb-877a-a5bb9df5d269" />
+    <LogHighlightingPattern pattern="^\s*INFO\s*$" formatId="6c083f50-56bc-4e71-9bde-db86a3faa90d" captureGroup="-1" action="HIGHLIGHT_LINE" fg="{&quot;lightRgb&quot;:-10316203,&quot;darkRgb&quot;:-10316203}" uuid="576f17af-59dd-4d10-a860-303096e9d255" />
+    <LogHighlightingPattern pattern="^\s*WARN\s*$" formatId="6c083f50-56bc-4e71-9bde-db86a3faa90d" captureGroup="-1" action="HIGHLIGHT_LINE" fg="{&quot;lightRgb&quot;:-6329600,&quot;darkRgb&quot;:-6329600}" bold="true" uuid="ec8bb56c-a8b1-4126-8c29-56ce582edcc6" />
+  </highlightingPatterns>
+  <parsingPatterns>
+    <LogParsingPattern name="Xdebug" pattern="\[(\d+)\](?: \[([A-Za-z ]+)\] ([A-Z]+):\s)?(.+)" timePattern="yyyy-MM-dd HH:mm:ss.SSSSSS" linePattern="^\[" severityId="2" categoryId="1" uuid="6c083f50-56bc-4e71-9bde-db86a3faa90d" />
+  </parsingPatterns>
+  <settingsVersion>13</settingsVersion>
+</State>


### PR DESCRIPTION
Adds highlighting based on the log severity (INFO, ERR or WARN)
Before:
<img width="627" height="203" alt="image" src="https://github.com/user-attachments/assets/40f34d20-10b6-4903-9dba-d904c444d221" />


After:
<img width="627" height="203" alt="image" src="https://github.com/user-attachments/assets/87adc060-52fd-43a7-b506-c6d2b5ce98cb" />
